### PR TITLE
setting page.clipRect only after delay

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,14 +122,6 @@ page.open(opts.url, function (status) {
 		};
 	}
 
-	if (opts.selector) {
-		page.clipRect = page.evaluate(function (el) {
-			return document
-				.querySelector(el)
-				.getBoundingClientRect();
-		}, opts.selector);
-	}
-
 	page.evaluate(function () {
 		var bgColor = window
 			.getComputedStyle(document.body)
@@ -141,6 +133,14 @@ page.open(opts.url, function (status) {
 	});
 
 	window.setTimeout(function () {
+		if (opts.selector) {
+			page.clipRect = page.evaluate(function (el) {
+				return document
+					.querySelector(el)
+					.getBoundingClientRect();
+			}, opts.selector);
+		}
+
 		log.call(console, page.renderBase64(opts.format));
 		phantom.exit();
 	}, opts.delay * 1000);

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ var isJpg = require('is-jpg');
 var isPng = require('is-png');
 var screenshot = require('./');
 var test = require('ava');
+var path = require('path');
 
 test('generate screenshot', function (t) {
 	t.plan(1);
@@ -41,6 +42,19 @@ test('capture a DOM element using the `selector` option', function (t) {
 		t.assert(imageSize(data).width === 1024);
 		t.assert(imageSize(data).height === 80);
 	}));
+});
+
+test('capture a DOM element using `selector` option only after delay', function (t) {
+	t.plan(2);
+
+	var stream = screenshot(path.join(__dirname, 'test', 'delayShowing.html'), '1024x768', {
+		selector: '.someElement',
+		delay: 5
+	});
+	stream.on('data', function (data) {
+		t.assert(imageSize(data).width === 300);
+		t.assert(imageSize(data).height === 200);
+	});
 });
 
 test('auth using the `username` and `password` options', function (t) {

--- a/test/delayShowing.html
+++ b/test/delayShowing.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+	<meta charset="UTF-8">
+	<title></title>
+
+	<style>
+		.someElement {
+			background: red;
+			width: 300px;
+			height: 200px;
+			display: none;
+		}
+	</style>
+</head>
+<body>
+	<div class="someElement">
+
+	</div>
+	<script>
+		window.setTimeout(function() {
+			document.querySelector('.someElement').style.display = 'block';
+		}, 5000)
+	</script>
+</body>
+</html>


### PR DESCRIPTION
Hello!
Thank you for module and sorry for my english.

I think better move setting page.clipRect (caused by `selector` parameter) to timeout function, to handle following case:
If element hidden by css (display:none) just after page loading and showing after 5 seconds (via JS for example) . getBoundingClientRect() returns wrong value
