### PR TITLE
Add option for disabling the ES5 shim

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ module.exports = function (url, size, opts) {
 		return typeof cookie === 'string' ? parseCookiePhantomjs(cookie) : cookie;
 	});
 
-	if (opts.es5shim){
-	  es5shim = fs.readFileSync(es5Shim, 'utf8');
+	if (opts.es5shim) {
+		es5shim = fs.readFileSync(es5Shim, 'utf8');
 	}
 
 	var cp = phantomBridge(path.join(__dirname, 'lib/index.js'), [

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,10 +50,10 @@ page.onError = function (err, trace) {
 	].join('\n'));
 };
 
-if (opts.es5shim){
-  page.onResourceReceived = function () {
-    page.injectJs(opts.es5shim);
-  };	
+if (opts.es5shim) {
+	page.onResourceReceived = function () {
+		page.injectJs(opts.es5shim);
+	};	
 }
 
 page.viewportSize = {


### PR DESCRIPTION
- In some cases, the ES5 shim may not be warranted or necessary, so make it optional with a disableShim option. This should not affect anyone currently using screenshot-stream.

The following code (taken from the readme) will produce blank screenshots as the code currently sits.

```js
var fs = require('fs');
var screenshot = require('screenshot-stream');

var stream = screenshot([website url here], '1024x768');

stream.pipe(fs.createWriteStream('pic-1024x768.png'));
```

Here's a small list of sites that will fail with the above code (and conversely work with the shim disabled):
- http://www.winonaymca.org/
- http://www.brownowlcreative.com/
- http://www.farmersfridge.com/