### PR TITLE
Ensure PhantomJS stderr is processed by line

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var es5Shim = require.resolve('es5-shim');
 var parseCookiePhantomjs = require('parse-cookie-phantomjs');
 var phantomBridge = require('phantom-bridge');
 var objectAssign = require('object-assign');
+var byline = require('byline');
 var es5shim;
 
 function handleCookies(cookies, url) {
@@ -60,7 +61,7 @@ module.exports = function (url, size, opts) {
 	process.stderr.setMaxListeners(0);
 
 	cp.stderr.setEncoding('utf8');
-	cp.stderr.on('data', function (data) {
+	byline(cp.stderr).on('data', function (data) {
 		data = data.trim();
 
 		if (/ phantomjs\[/.test(data)) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "dependencies": {
     "base64-stream": "^0.1.2",
+    "byline": "^4.2.1",
     "es5-shim": "^4.0.3",
     "object-assign": "^4.0.1",
     "parse-cookie-phantomjs": "^1.0.0",


### PR DESCRIPTION
- It adds `byline` as a dependency, hope it s fine, otherwise i d like to get a suggestion.
-  ~~It also makes `xo` happier when validating `stream.js`, previously there was too many nested callbacks~~

-

Fixes #22.