### PR TITLE
Remove `es5-shim`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,11 @@
 'use strict';
-var fs = require('fs');
 var path = require('path');
 var urlMod = require('url');
 var base64Stream = require('base64-stream');
-var es5Shim = require.resolve('es5-shim');
 var parseCookiePhantomjs = require('parse-cookie-phantomjs');
 var phantomBridge = require('phantom-bridge');
 var objectAssign = require('object-assign');
 var byline = require('byline');
-var es5shim;
 
 function handleCookies(cookies, url) {
 	var parsedUrl = urlMod.parse(url);
@@ -37,16 +34,11 @@ module.exports = function (url, size, opts) {
 	opts.url = url;
 	opts.width = size.split(/x/i)[0] * opts.scale;
 	opts.height = size.split(/x/i)[1] * opts.scale;
-	opts.es5shim = opts.es5shim === false ? null : path.relative(__dirname, es5Shim);
 	opts.format = opts.format ? opts.format : 'png';
 	opts.cookies = handleCookies(opts.cookies, opts.url);
 
 	if (opts.format === 'jpg') {
 		opts.format = 'jpeg';
-	}
-
-	if (opts.es5shim) {
-		es5shim = fs.readFileSync(es5Shim, 'utf8');
 	}
 
 	var cp = phantomBridge(path.join(__dirname, 'stream.js'), [
@@ -69,10 +61,6 @@ module.exports = function (url, size, opts) {
 		}
 
 		if (/http:\/\/requirejs.org\/docs\/errors.html#mismatch/.test(data)) {
-			return;
-		}
-
-		if (es5shim && es5shim.indexOf(data) !== -1) {
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "base64-stream": "^0.1.2",
     "byline": "^4.2.1",
-    "es5-shim": "^4.0.3",
     "object-assign": "^4.0.1",
     "parse-cookie-phantomjs": "^1.0.0",
     "phantom-bridge": "^2.0.0"

--- a/stream.js
+++ b/stream.js
@@ -37,12 +37,6 @@ page.onError = function (err, trace) {
 	console.error('WARN: ' + err + formatTrace(trace[0]));
 };
 
-if (opts.es5shim) {
-	page.onResourceReceived = function () {
-		page.injectJs(opts.es5shim);
-	};
-}
-
 page.viewportSize = {
 	width: opts.width,
 	height: opts.height


### PR DESCRIPTION
Since `phantomjs` uses a newer WebKit, `es5-shim` should no longer be needed.