### PR TITLE
Warn on resource errors

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -37,6 +37,10 @@ page.onError = function (err, trace) {
 	console.error('WARN: ' + err + formatTrace(trace[0]));
 };
 
+page.onResourceError = function (resourceError) {
+	console.error('WARN: Unable to load resource #' + resourceError.id + ' (' + resourceError.errorString + ') → ' + resourceError.url);
+};
+
 page.viewportSize = {
 	width: opts.width,
 	height: opts.height


### PR DESCRIPTION
This PR emits a `'warn'` event when phantomjs fails to load external resources referenced within the page.

Useful for dealing with connectivity errors etc, which could otherwise result in incorrect screenshots with no way of detecting in code that anything went wrong (if an image or css file fails to load, say).

The PhantomJS docs have [details](http://phantomjs.org/api/webpage/handler/on-resource-error.html) of which error information is available to the callback if you want to change the message.

Let me know if there's anything I can do to help get this merged!