### PR TITLE
Allows `scale` option to be used in conjunction with `selector` option

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -106,10 +106,10 @@ page.open(opts.url, function (status) {
 					.getBoundingClientRect();
 			}, opts.selector);
 
-      clipRect.height = clipRect.height * page.zoomFactor;
-      clipRect.width = clipRect.width * page.zoomFactor;
+      			clipRect.height = clipRect.height * page.zoomFactor;
+      			clipRect.width = clipRect.width * page.zoomFactor;
 
-      page.clipRect = clipRect  
+      			page.clipRect = clipRect  
 		}
 
 		log.call(console, page.renderBase64(opts.format));

--- a/stream.js
+++ b/stream.js
@@ -105,11 +105,13 @@ page.open(opts.url, function (status) {
 					.querySelector(el)
 					.getBoundingClientRect();
 			}, opts.selector);
-
-      			clipRect.height = clipRect.height * page.zoomFactor;
-      			clipRect.width = clipRect.width * page.zoomFactor;
-
-      			page.clipRect = clipRect  
+			
+			clipRect.height = clipRect.height * page.zoomFactor;
+      clipRect.width = clipRect.width * page.zoomFactor;
+			clipRect.top = clipRect.top * page.zoomFactor;
+			clipRect.left = clipRect.left * page.zoomFactor;
+			
+			page.clipRect = clipRect  
 		}
 
 		log.call(console, page.renderBase64(opts.format));

--- a/stream.js
+++ b/stream.js
@@ -100,11 +100,16 @@ page.open(opts.url, function (status) {
 		}
 
 		if (opts.selector) {
-			page.clipRect = page.evaluate(function (el) {
+			var clipRect = page.evaluate(function (el) {
 				return document
 					.querySelector(el)
 					.getBoundingClientRect();
 			}, opts.selector);
+
+      clipRect.height = clipRect.height * page.zoomFactor;
+      clipRect.width = clipRect.width * page.zoomFactor;
+
+      page.clipRect = clipRect  
 		}
 
 		log.call(console, page.renderBase64(opts.format));


### PR DESCRIPTION
I found that if `scale` was != 1, the clipRect would be unaffected, so this PR simply multiplies page.clipRect's `width` and `height` properties by page.zoomFactor.