### PR TITLE
fix multiline error messages

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -31,11 +31,13 @@ page.settings.resourceTimeout = (opts.timeout || 60) * 1000;
 phantom.cookies = opts.cookies;
 
 phantom.onError = function (err, trace) {
+	err = err.replace(/\n/g, '');
 	console.error('PHANTOM ERROR: ' + err + formatTrace(trace[0]));
 	phantom.exit(1);
 };
 
 page.onError = function (err, trace) {
+	err = err.replace(/\n/g, '');
 	console.error('WARN: ' + err + formatTrace(trace[0]));
 };
 

--- a/test/fixtures/test-error-script.html
+++ b/test/fixtures/test-error-script.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title></title>
+	</head>
+	<body>
+		<div></div>
+		<script>
+			new {
+				foo: {
+					bar: 'baz'
+				}
+			};
+		</script>
+	</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,12 @@ test('hide elements using the `hide` option', async t => {
 	png.decode(pixels => t.is(pixels[0], 255));
 });
 
+test('ignore multiline page errors', async t => {
+	const fixture = path.join(__dirname, 'fixtures', 'test-error-script.html');
+	const stream = screenshotStream(fixture, '100x100');
+	t.true(isPng(await getStream.buffer(stream)));
+});
+
 test('auth using the `username` and `password` options', async t => {
 	const stream = screenshotStream('http://httpbin.org/basic-auth/user/passwd', '1024x768', {
 		username: 'user',


### PR DESCRIPTION
I believe this solves https://github.com/sindresorhus/pageres/issues/256 and https://github.com/sindresorhus/pageres/issues/244.

The error `expressen.se` generated was the following

```
WARN: TypeError: Object is not a constructor (evaluating '{ 
visitor : {  
age : '0',  
gender : '0' 
}, 
inventory : {
}
}') → about:blank on line 9 in function global code
```

But these where logged all as individual lines. So the first line was omitted because it has `WARN` at the start. But the following line is `visitor : {` which was interpreted as a real error. By removing the newlines, it is logged as one string.

I did the same for `phantom.onError`. Not sure if it is necessary for a specific case but I thought it wouldn't hurt.