### PR TITLE
extend `screenshot` by PhantomJS command-line options

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,18 @@ const handleCookies = (cookies, url) => {
 	});
 };
 
-module.exports = (url, size, opts) => {
+module.exports = (url, size, opts, phantomOpts) => {
 	opts = Object.assign({
 		delay: 0,
 		scale: 1,
 		format: 'png'
 	}, opts);
+
+	phantomOpts = phantomOpts || [
+		'--ignore-ssl-errors=true',
+		'--local-to-remote-url-access=true',
+		'--ssl-protocol=any'
+	];
 
 	const args = Object.assign(opts, {
 		url,
@@ -42,12 +48,9 @@ module.exports = (url, size, opts) => {
 		script: /\.js$/.test(opts.script) ? fs.readFileSync(opts.script, 'utf8') : opts.script
 	});
 
-	const cp = phantomBridge(path.join(__dirname, 'stream.js'), [
-		'--ignore-ssl-errors=true',
-		'--local-to-remote-url-access=true',
-		'--ssl-protocol=any',
-		JSON.stringify(args)
-	]);
+	const cp = phantomBridge(path.join(__dirname, 'stream.js'),
+		phantomOpts.concat(JSON.stringify(args))
+	);
 
 	const stream = base64Stream.decode();
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ stream.pipe(fs.createWriteStream('google.com-1024x768.png'));
 
 ## API
 
-### screenshot(url, size, [options])
+### screenshot(url, size [, options] [, phantomOptions])
 
 #### url
 
@@ -133,6 +133,13 @@ Scale webpage `n` times.
 Type: `string`
 
 Set a custom user agent.
+
+#### phantomOptions
+
+Type: `Array`<br>
+Default: `['--ignore-ssl-errors=true', '--local-to-remote-url-access=true', '--ssl-protocol=any']`
+
+A list of [command-line options](http://phantomjs.org/api/command-line.html) passed to PhantomJS. Make sure to add default options to `phantomOptions`.
 
 #### .on('error', callback)
 

--- a/test.js
+++ b/test.js
@@ -189,3 +189,11 @@ test('resource timeout', async t => {
 
 	await s.close();
 });
+
+test('if phantomOpts contains [\'--version\'] no screenshot is taken', async t => {
+	// TODO: phantom-bridge's stream emits non base64 encoded version string
+	//       thus the decoded stream returned by `screenshotStream` is corrupted
+	//       which makes a straight forward test impossible
+	const stream = screenshotStream('http://yeoman.io', '1024x768', {}, ['--version']);
+	t.false(isPng(await getStream.buffer(stream)));
+});


### PR DESCRIPTION
In order to use `screenshot-stream` behind a HTTP proxy
enable passing PhantomJS command-line options [1].

[1] http://phantomjs.org/api/command-line.html